### PR TITLE
Feedback/review todo section

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -224,16 +224,6 @@ def convert_to_markdown_v2(output_data: dict,
                     value = emphasize_header(value.strip(), only_markdown=True)
                     markdown_text += f"{value}\n\n"
         elif 'todo sections' in key_nice.lower():
-
-            def format_multiline_html_item(file: str, line_range: Tuple[int, int], content: str, url: str) -> str:
-                label = f"{file} [{line_range[0]}-{line_range[1]}]" if line_range[0] != line_range[1] else f"{file} [{line_range[0]}]"
-                first_line, *rest_lines = content.strip().split("\n")
-                if rest_lines:
-                    rest = "<br>".join(rest_lines)
-                    return f"<li><a href='{url}'>{label}</a>: {first_line}<br><blockquote>{rest}</blockquote></li>"
-                else:
-                    return f"<li><a href='{url}'>{label}</a>: {first_line}</li>"
-
             def format_todo_item(todo_item: TodoItem) -> str:
                 relevant_file = todo_item.get('relevant_file', '').strip()
                 line_range = todo_item.get('line_range', [])

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -274,7 +274,7 @@ def convert_to_markdown_v2(output_data: dict,
                 if is_value_no(value):
                     markdown_text += f"{emoji}&nbsp;<strong>No TODO sections</strong>"
                 else:
-                    markdown_text += f"<details><summary>{emoji}&nbsp;<strong>TODO sections</strong></summary>\n\n"
+                    markdown_text += f"<details><summary>{emoji}&nbsp;<strong>TODO sections ({len(value)} items)</strong></summary>\n\n"
                     if isinstance(value, list):
                         markdown_text += "<ul>\n"
                         for todo_item in value:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -164,6 +164,7 @@ def convert_to_markdown_v2(output_data: dict,
     if gfm_supported:
         markdown_text += "<table>\n"
 
+    todos_summary = output_data['review'].pop('todos_summary', '')
     for key, value in output_data['review'].items():
         if value is None or value == '' or value == {} or value == []:
             if key.lower() not in ['can_be_split', 'key_issues_to_review']:
@@ -274,7 +275,7 @@ def convert_to_markdown_v2(output_data: dict,
                 if is_value_no(value):
                     markdown_text += f"{emoji}&nbsp;<strong>No TODO sections</strong>"
                 else:
-                    markdown_text += f"<details><summary>{emoji}&nbsp;<strong>TODO sections ({len(value)} items)</strong></summary>\n\n"
+                    markdown_text += f"{emoji}&nbsp;<strong>TODO sections ({len(value)} items)</strong>\n<details><summary>{todos_summary}</summary>\n\n"
                     if isinstance(value, list):
                         markdown_text += "<ul>\n"
                         for todo_item in value:
@@ -288,7 +289,7 @@ def convert_to_markdown_v2(output_data: dict,
                 if is_value_no(value):
                     markdown_text += f"### {emoji} No TODO sections\n\n"
                 else:
-                    markdown_text += f"<details><summary>### {emoji} TODO sections</summary>\n\n"
+                    markdown_text += f"### {emoji} TODO sections ({len(value)} items)\n<details><summary>{todos_summary}</summary>\n\n"
                     if isinstance(value, list):
                         for todo_item in value:
                             markdown_text += f"- {format_todo_item(todo_item)}\n"

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -109,6 +109,18 @@ class Review(BaseModel):
 {%- endif %}
 {%- if require_todo_scan %}
     todo_sections: Union[List[TodoSection], str] = Field(description="A list of TODO comments found in the code. Return 'No' (as a string) if there are no TODO comments.")
+    todos_summary: str = Field(description="When writing TODO section summaries, use this format:
+      [count] TODOs found about [functional area based on TODO content]
+
+      - The [count] is the number of TODO items, equal to the length of the `todo_sections` list.
+      - Functional areas describe what the TODOs are about:
+          testing, error handling, validation, documentation, performance, 
+          security, logging, refactoring, API design, UI/UX
+
+      Example:
+        3 TODOs found about input validation and error handling
+      
+      Return 'No' (as a string) if there are no TODO comments.")
 {%- endif %}
 {%- if require_can_be_split_review %}
     can_be_split: List[SubPR] = Field(min_items=0, max_items=3, description="Can this PR, which contains {{ num_pr_files }} changed files in total, be divided into smaller sub-PRs with distinct tasks that can be reviewed and merged independently, regardless of the order ? Make sure that the sub-PRs are indeed independent, with no code dependencies between them, and that each sub-PR represent a meaningful independent task. Output an empty list if the PR code does not need to be split.")
@@ -157,6 +169,8 @@ review:
   security_concerns: |
     No
   todo_sections:
+    No
+  todos_summary:
     No
 {%- if require_can_be_split_review %}
   can_be_split:
@@ -277,6 +291,8 @@ review:
   security_concerns: |
     No
   todo_sections:
+    No
+  todos_summary:
     No
 {%- if require_can_be_split_review %}
   can_be_split:


### PR DESCRIPTION
#### 변경 전 
<img width="196" alt="image" src="https://github.com/user-attachments/assets/ff09e402-aff2-41f7-81e5-fd1830451ce6" />

위와 같이 기본적으로 접혀 있으면 사용자가 펼치지 않고 지나칠 수 있을 것 같아, 펼치게 하게 유도하기 위해 약간의 내용을 추가했습니다.
 1. TODO 섹션 옆에 항목 개수 표시
 2. TODO 내용을 한 줄로 요약해 표시

#### 변경 후
<img width="488" alt="image" src="https://github.com/user-attachments/assets/f618864c-4dd8-4d29-846e-6d63604ac523" />

#### 구현하지 않은 아이디어
- 항목이 1개뿐이어도 펼쳐야 하는 번거로움이 있을 것 같아, 
  문자열 길이를 기준으로 일정 길이를 초과할 때만 펼쳐지도록 할지 고민했지만, 우선 구현하지 않았습니다.