### PR TITLE
todo section의 내용이 10줄 이하이면 기본적으로 펼쳐져 있도록 수정

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -260,12 +260,9 @@ def convert_to_markdown_v2(output_data: dict,
                 else:
                     return file_ref
 
-            if gfm_supported:
-                markdown_text += f"<tr><td>"
-                if is_value_no(value):
-                    markdown_text += f"{emoji}&nbsp;<strong>No TODO sections</strong>"
-                else:
-                    markdown_text += f"{emoji}&nbsp;<strong>TODO sections ({len(value)} items)</strong>\n<details><summary>{todos_summary}</summary>\n\n"
+            def format_todo_items(value: list[TodoItem] | TodoItem) -> str: 
+                markdown_text = ""
+                if gfm_supported:
                     if isinstance(value, list):
                         markdown_text += "<ul>\n"
                         for todo_item in value:
@@ -273,18 +270,33 @@ def convert_to_markdown_v2(output_data: dict,
                         markdown_text += "</ul>\n"
                     else:
                         markdown_text += f"<p>{format_todo_item(value)}</p>\n"
-                    markdown_text += "\n</details>\n"
-                markdown_text += f"</td></tr>\n"
-            else:
-                if is_value_no(value):
-                    markdown_text += f"### {emoji} No TODO sections\n\n"
                 else:
-                    markdown_text += f"### {emoji} TODO sections ({len(value)} items)\n<details><summary>{todos_summary}</summary>\n\n"
                     if isinstance(value, list):
                         for todo_item in value:
                             markdown_text += f"- {format_todo_item(todo_item)}\n"
                     else:
                         markdown_text += f"- {format_todo_item(value)}\n"
+                return markdown_text
+ 
+            markdown_todo_items = format_todo_items(value)
+            EXPAND_LINE_THRESHOLD = 10
+            details_open_attr = " open" if markdown_todo_items.count("\n") + 1 <= EXPAND_LINE_THRESHOLD else ""
+            if gfm_supported:
+                markdown_text += "<tr><td>"
+                if is_value_no(value):
+                    markdown_text += f"{emoji}&nbsp;<strong>No TODO sections</strong>"
+                else:
+                    markdown_text += f"{emoji}&nbsp;<strong>TODO sections ({len(value)} items)</strong>\n"
+                    markdown_text += f"<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
+                    markdown_text += markdown_todo_items
+                    markdown_text += "\n</details>\n"
+                markdown_text += "</td></tr>\n"
+            else:
+                if is_value_no(value):
+                    markdown_text += f"### {emoji} No TODO sections\n\n"
+                else:
+                    markdown_text += f"### {emoji} TODO sections ({len(value)} items)\n<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
+                    markdown_text += markdown_todo_items
                     markdown_text += "\n</details>\n\n"
         elif 'can be split' in key_nice.lower():
             if gfm_supported:

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -281,12 +281,14 @@ def convert_to_markdown_v2(output_data: dict,
             markdown_todo_items = format_todo_items(value)
             EXPAND_LINE_THRESHOLD = 10
             details_open_attr = " open" if markdown_todo_items.count("\n") + 1 <= EXPAND_LINE_THRESHOLD else ""
+            
+            todo_entry_label = f"{len(value)} " + "entries" if len(value) > 1 else "entry"
             if gfm_supported:
                 markdown_text += "<tr><td>"
                 if is_value_no(value):
                     markdown_text += f"{emoji}&nbsp;<strong>No TODO sections</strong>"
                 else:
-                    markdown_text += f"{emoji}&nbsp;<strong>TODO sections ({len(value)} items)</strong>\n"
+                    markdown_text += f"{emoji}&nbsp;<strong>TODO sections ({todo_entry_label})</strong>\n"
                     markdown_text += f"<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
                     markdown_text += markdown_todo_items
                     markdown_text += "\n</details>\n"
@@ -295,7 +297,7 @@ def convert_to_markdown_v2(output_data: dict,
                 if is_value_no(value):
                     markdown_text += f"### {emoji} No TODO sections\n\n"
                 else:
-                    markdown_text += f"### {emoji} TODO sections ({len(value)} items)\n<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
+                    markdown_text += f"### {emoji} TODO sections ({todo_entry_label})\n<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
                     markdown_text += markdown_todo_items
                     markdown_text += "\n</details>\n\n"
         elif 'can be split' in key_nice.lower():

--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -164,7 +164,7 @@ def convert_to_markdown_v2(output_data: dict,
     if gfm_supported:
         markdown_text += "<table>\n"
 
-    todos_summary = output_data['review'].pop('todos_summary', '')
+    todo_summary = output_data['review'].pop('todo_summary', '')
     for key, value in output_data['review'].items():
         if value is None or value == '' or value == {} or value == []:
             if key.lower() not in ['can_be_split', 'key_issues_to_review']:
@@ -289,7 +289,7 @@ def convert_to_markdown_v2(output_data: dict,
                     markdown_text += f"{emoji}&nbsp;<strong>No TODO sections</strong>"
                 else:
                     markdown_text += f"{emoji}&nbsp;<strong>TODO sections ({todo_entry_label})</strong>\n"
-                    markdown_text += f"<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
+                    markdown_text += f"<details{details_open_attr}><summary>{todo_summary}</summary>\n\n"
                     markdown_text += markdown_todo_items
                     markdown_text += "\n</details>\n"
                 markdown_text += "</td></tr>\n"
@@ -297,7 +297,7 @@ def convert_to_markdown_v2(output_data: dict,
                 if is_value_no(value):
                     markdown_text += f"### {emoji} No TODO sections\n\n"
                 else:
-                    markdown_text += f"### {emoji} TODO sections ({todo_entry_label})\n<details{details_open_attr}><summary>{todos_summary}</summary>\n\n"
+                    markdown_text += f"### {emoji} TODO sections ({todo_entry_label})\n<details{details_open_attr}><summary>{todo_summary}</summary>\n\n"
                     markdown_text += markdown_todo_items
                     markdown_text += "\n</details>\n\n"
         elif 'can be split' in key_nice.lower():

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -75,7 +75,7 @@ class KeyIssuesComponentLink(BaseModel):
 class TodoSection(BaseModel):
     relevant_file: str = Field(description="The file containing the TODO comment")
     line_range: Tuple[int, int] = Field(description="Start and end line numbers of the TODO comment (inclusive). Must be a tuple of two integers, e.g., (7, 7) for a single line or (7, 10) for a range. Do not use list format [7, 7].")
-    content: str = Field(description="The content of the TODO comment. Only include actual TODO comments within code comments (e.g., lines starting with '#', '//', '/*', '<!--').  Remove leading 'TODO' prefixes. Include lines like '# TODO', even if empty after prefix removal. Exclude TODOs outside comments or without appropriate prefixes.")
+    content: str = Field(description="The content of the TODO comment. Only include actual TODO comments within code comments (e.g., lines starting with '#', '//', '/*', '<!--').  Remove leading 'TODO' prefixes. Include lines like '# TODO', even if empty after prefix removal. Exclude TODOs outside comments or without appropriate prefixes. Use | block style only when the line range covers multiple lines (e.g., (7, 10)).")
 
 {%- if related_tickets %}
 

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -168,9 +168,9 @@ review:
     - ...
   security_concerns: |
     No
-  todo_sections:
+  todo_sections: |
     No
-  todos_summary:
+  todos_summary: |
     No
 {%- if require_can_be_split_review %}
   can_be_split:
@@ -290,9 +290,9 @@ review:
     - ...
   security_concerns: |
     No
-  todo_sections:
+  todo_sections: |
     No
-  todos_summary:
+  todos_summary: |
     No
 {%- if require_can_be_split_review %}
   can_be_split:

--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -109,18 +109,15 @@ class Review(BaseModel):
 {%- endif %}
 {%- if require_todo_scan %}
     todo_sections: Union[List[TodoSection], str] = Field(description="A list of TODO comments found in the code. Return 'No' (as a string) if there are no TODO comments.")
-    todos_summary: str = Field(description="When writing TODO section summaries, use this format:
-      [count] TODOs found about [functional area based on TODO content]
-
-      - The [count] is the number of TODO items, equal to the length of the `todo_sections` list.
-      - Functional areas describe what the TODOs are about:
-          testing, error handling, validation, documentation, performance, 
+    todo_summary: str = Field(description="Summarize the functional areas of the TODO comments found in the code.
+      - Focus on describing the *functional areas* of the TODOs, such as:
+          testing, error handling, validation, documentation, performance,
           security, logging, refactoring, API design, UI/UX
 
-      Example:
-        3 TODOs found about input validation and error handling
-      
-      Return 'No' (as a string) if there are no TODO comments.")
+      - Example:
+          TODO related to input validation and error handling
+
+      - Return 'No' (as a string) if there are no TODO comments.")
 {%- endif %}
 {%- if require_can_be_split_review %}
     can_be_split: List[SubPR] = Field(min_items=0, max_items=3, description="Can this PR, which contains {{ num_pr_files }} changed files in total, be divided into smaller sub-PRs with distinct tasks that can be reviewed and merged independently, regardless of the order ? Make sure that the sub-PRs are indeed independent, with no code dependencies between them, and that each sub-PR represent a meaningful independent task. Output an empty list if the PR code does not need to be split.")
@@ -170,7 +167,7 @@ review:
     No
   todo_sections: |
     No
-  todos_summary: |
+  todo_summary: |
     No
 {%- if require_can_be_split_review %}
   can_be_split:
@@ -292,7 +289,7 @@ review:
     No
   todo_sections: |
     No
-  todos_summary: |
+  todo_summary: |
     No
 {%- if require_can_be_split_review %}
   can_be_split:


### PR DESCRIPTION
### **PR Type**

#### 기능 추가 
todo section이 10줄 이하일 때는 펼쳐진 상태로 보이게 하는 기능을 추가했습니다.

<img width="444" alt="image" src="https://github.com/user-attachments/assets/b3c34e4a-ef7a-4406-aafc-b943e84ac117" />

#### 버그 수정

<img width="478" alt="image" src="https://github.com/user-attachments/assets/77c251d3-f187-4414-9118-497f63b37b23" />

```python
# todo test1
# todo test2
```
위 사진처럼 주석의 결과 `test1\ntest2`로 나오는 버그 수정
원인은 아래와 같이 yaml 파일에 \n이 직접 포함되었기 때문입니다. 
yaml에 \n이 있으면 python string으로 변환할 때 `\\n`으로 치환됩니다.

따라서 multi line이면 | 를 사용하도록 프롬프트를 수정했습니다.
|를 사용하면 python string으로 `\n`이 나옵니다.

`As-is`
![image](https://github.com/user-attachments/assets/af3f04ad-a092-499e-95a0-a728a51d1638)
`To-be`
![image](https://github.com/user-attachments/assets/f062f2ec-953b-4e3f-ad86-ba6dbea674c1)

___

### **Description**
- Automatically expands TODO sections if content is 10 lines or fewer

- Refactors and standardizes TODO section and summary formatting

- Updates prompt templates to use block scalar for TODO fields


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Auto-expand and refactor TODO section rendering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/algo/utils.py

<li>Adds logic to auto-expand TODO sections if line count ≤ 10<br> <li> Refactors TODO formatting for clarity and consistency<br> <li> Introduces a helper function for formatting TODO items<br> <li> Improves details/summary rendering for both GFM and non-GFM markdown


</details>


  </td>
  <td><a href="https://github.com/PullPullers/pr-agent-qodo/pull/4/files#diff-6b9df72d53c6f0d89fb142c210238a276c0782305e0024d16fbfcaf72c2e2b53">+24/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Use block scalar for TODO fields in prompts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<li>Changes <code>todo_sections</code> and <code>todos_summary</code> to use block scalar (|)<br> <li> Ensures consistent formatting for TODO-related prompt fields


</details>


  </td>
  <td><a href="https://github.com/PullPullers/pr-agent-qodo/pull/4/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>