### PR TITLE
feat: extract 'empty TODO' comments with accurate line info

### DIFF
--- a/pr_agent/settings/pr_reviewer_prompts.toml
+++ b/pr_agent/settings/pr_reviewer_prompts.toml
@@ -75,7 +75,7 @@ class KeyIssuesComponentLink(BaseModel):
 class TodoSection(BaseModel):
     relevant_file: str = Field(description="The file containing the TODO comment")
     line_range: Tuple[int, int] = Field(description="Start and end line numbers of the TODO comment (inclusive). Must be a tuple of two integers, e.g., (7, 7) for a single line or (7, 10) for a range. Do not use list format [7, 7].")
-    content: str = Field(description="The content of the TODO comment. Only include actual TODO comments within code comments (e.g., lines starting with '#', '//', '/*', '<!--').  Remove leading 'TODO' prefixes. Include lines like '# TODO', even if empty after prefix removal. Exclude TODOs outside comments or without appropriate prefixes.")
+    content: str = Field(description="The content of the TODO comment. Only include TODOs that appear inside code comments (e.g., lines starting with '#', '//', '/*', '<!--'). Remove the 'TODO' prefix and any punctuation directly after it. If the comment is only 'TODO' (e.g., '# TODO'), return 'empty TODO' as the content. Exclude TODOs not in comment syntax or without appropriate prefixes. Multi-line TODOs must be grouped into a single entry if they are consecutive.")
 
 {%- if related_tickets %}
 


### PR DESCRIPTION
### **User description**
내용 없이 `#TODO`주석만 존재하는 경우 `empty TODO`가 표기되도록 프롬프트를 수정했습니다.
해당 기능을 main 브랜치에 취합해야 하는지 여부는 논의가 필요합니다.

## 수정 내용
프롬프트를 수정하여 TODO 주석의 내용이 없는 경우 `empty TODO` 표기 (이 경우 코드 라인도 정상적으로 추출됨)

## 수정 전/후 비교
수정 전 : `test.py [19]:` (content 없이 파일명과 라인만 표시)
수정 후: `test.py [19]: empty TODO`


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced TODO extraction to handle empty TODO comments.

- Updated prompt to label empty TODOs as 'empty TODO'.

- Improved instructions for grouping multi-line TODOs.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr_reviewer_prompts.toml</strong><dd><code>Update TODO extraction prompt for empty and multi-line comments</code></dd></summary>
<hr>

pr_agent/settings/pr_reviewer_prompts.toml

<li>Refined the <code>content</code> field description for TODO extraction.<br> <li> Specified that empty TODO comments are labeled as 'empty TODO'.<br> <li> Clarified removal of 'TODO' prefix and punctuation.<br> <li> Added instruction to group consecutive multi-line TODOs.


</details>


  </td>
  <td><a href="https://github.com/PullPullers/pr-agent-qodo/pull/6/files#diff-2e1ca45d2d8635b5f9cde801d9d210f6516e7f15d45dd9b0be134ac91e7a2e63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>